### PR TITLE
Added "Append all links with bracketed perma.cc links" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 This is a Google Apps Script that can be used to add [Perma.cc](https://perma.cc/) links to a Google Doc, either by:
 - replacing all links in a document with Perma.cc links
 - replacing all links in a selection with Perma.cc links
-- appenidng bracketed Perma.cc links to all links
+- appending bracketed Perma.cc links to all links (usually for a bibliography)
 - appending bracketed Perma.cc links to footnotes
 - appending bracketed Perma.cc links to footnotes in a [Bluebook-compliant](https://perma.cc/9GGN-W7GX) format.
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 This is a Google Apps Script that can be used to add [Perma.cc](https://perma.cc/) links to a Google Doc, either by:
 - replacing all links in a document with Perma.cc links
 - replacing all links in a selection with Perma.cc links
+- appenidng bracketed Perma.cc links to all links
 - appending bracketed Perma.cc links to footnotes
 - appending bracketed Perma.cc links to footnotes in a [Bluebook-compliant](https://perma.cc/9GGN-W7GX) format.
 

--- a/permaccize.gs
+++ b/permaccize.gs
@@ -81,7 +81,7 @@ function replaceAllLinks() {
   }
 }
 
-function appendLinksToParagraphs(paragraphs, api_key, bluebook) {
+function appendLinksToText(paragraphs, api_key, bluebook) {
   var links = [];
   var permalinks = {};
 
@@ -163,10 +163,12 @@ function appendFootnoteLinks(bluebook = false) {
   var doc = DocumentApp.getActiveDocument();
 
   var footnotes = doc.getFootnotes();
+  var paragraphs = []
   for (var f = 0; f < footnotes.length; f++) {
-    paragraphs = footnotes[f].getFootnoteContents().getParagraphs();
-    appendLinksToParagraphs(paragraphs, api_key, bluebook)
+    paragraphs = paragraphs.concat(footnotes[f].getFootnoteContents().getParagraphs());
   }
+  appendLinksToText(paragraphs, api_key, bluebook)
+
 }
 
 function promptForKey() {
@@ -293,7 +295,7 @@ function getAllLinks(element) {
   return links;
 }
 
-function appendAllLinks() {
+function appendBibliographyLinks() {
   var api_key = promptForKey();
 
   // Get the active document and its body
@@ -305,7 +307,7 @@ function appendAllLinks() {
   
   // Get all paragraphs in the document
   var paragraphs = body.getParagraphs();
-  appendLinksToParagraphs(paragraphs, api_key, false)
+  appendLinksToText(paragraphs, api_key, false)
 }
 
 function onOpen() {
@@ -314,8 +316,8 @@ function onOpen() {
     .createMenu("Perma.cc")
     .addItem("Replace all links with Perma.cc links", "replaceAllLinks")
     .addItem(
-      "Append all links with bracketed Perma.cc links",
-      "appendAllLinks"
+      "Append all links with bracketed Perma.cc links (bibliography)",
+      "appendBibliographyLinks"
       )
     .addItem(
       "Append footnote links with bracketed Perma.cc links",


### PR DESCRIPTION
Hi!

Making a little PR here to add an option for the Research style of footnotes.

Essentially, I moved the code that scans an array of paragraphs, grabs the links, and appends a perma.cc version of that link to that paragraph to a generic function, `appendLinksToParagraphs(paragraphs, api_key, bluebook)` and then `appendAllLinks` call that on the whole document instead of each footnote. In the future, I can add the "selection" functionality you added with "replace all links".

I tested it in footnotes, footnotes with Bluebook, and the new append all links option.